### PR TITLE
Fix metadata, document FRED extension, update CI actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,13 +10,8 @@ on:
     branches:
       - main
 
-  # Run on pull requests targeting the master branch
-  pull_request:
-    branches:
-      - main
-
   # Allows manual triggering of the workflow
-  workflow_dispatch: 
+  workflow_dispatch:
 
 jobs:
   build:
@@ -26,10 +21,10 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a className="gh-badge" href="https://datahub.io/core/s-and-p-500"><img src="https://badgen.net/badge/icon/View%20on%20datahub.io/orange?icon=https://datahub.io/datahub-cube-badge-icon.svg&label&scale=1.25" alt="badge" /></a>
 
 S&P 500 index data including level, dividend, earnings and P/E ratio on a
-monthly basis since 1870. The S&P 500 (Standard and Poor's 500) is a
+monthly basis since 1871. The S&P 500 (Standard and Poor's 500) is a
 free-float, capitalization-weighted index of the top 500 publicly listed stocks
 in the US (top 500 by market cap).
 
@@ -9,9 +9,15 @@ in the US (top 500 by market cap).
 
 The data provided here is a tidied and CSV'd version of that collected and
 prepared by the Economist Robert Shiller and made [available on his
-website][shiller].
+website][shiller]. Recent months (beyond what is covered by the Shiller
+dataset) are extended automatically with S&P 500 price data from the
+[Federal Reserve Bank of St. Louis (FRED)][fred]. Note that these
+FRED-only rows contain only the `SP500` price; the `Dividend`, `Earnings`,
+`Consumer Price Index`, `Long Interest Rate`, `Real Price`, `Real Dividend`,
+`Real Earnings`, and `PE10` fields are `0` for those rows.
 
 [shiller]: http://www.econ.yale.edu/~shiller/data.htm
+[fred]: https://fred.stlouisfed.org/series/SP500
 
 ### Source Data Construction
 

--- a/datapackage.json
+++ b/datapackage.json
@@ -81,7 +81,8 @@
           }
         ]
       },
-      "name": "data"
+      "name": "data",
+      "description": "Monthly S&P 500 index data from 1871 to present, including price, dividend, earnings, CPI, interest rate, inflation-adjusted values, and the Shiller CAPE (PE10) ratio."
     }
   ],
   "related": [

--- a/datapackage.json
+++ b/datapackage.json
@@ -4,7 +4,7 @@
   "licenses": [
     {
       "name": "ODC-PDDL-1.0",
-      "path": "http://opendatacommons.org/licenses/pddl/",
+      "path": "https://opendatacommons.org/licenses/pddl/",
       "title": "Open Data Commons Public Domain Dedication and License v1.0"
     }
   ],
@@ -13,6 +13,11 @@
       "name": "Robert Shiller",
       "path": "http://www.econ.yale.edu/~shiller/data.htm",
       "title": "Robert Shiller"
+    },
+    {
+      "name": "Federal Reserve Bank of St. Louis (FRED)",
+      "path": "https://fred.stlouisfed.org/series/SP500",
+      "title": "S&P 500 Index (FRED)"
     }
   ],
   "contributors": [
@@ -47,14 +52,17 @@
           },
           {
             "type": "number",
+            "description": "Dividend per share (monthly, annualised)",
             "name": "Dividend"
           },
           {
             "type": "number",
+            "description": "Earnings per share (monthly, annualised)",
             "name": "Earnings"
           },
           {
             "type": "number",
+            "description": "Consumer Price Index (CPI-U); pre-1913 spliced from Warren-Pearson price index",
             "name": "Consumer Price Index"
           },
           {
@@ -64,14 +72,17 @@
           },
           {
             "type": "number",
+            "description": "Inflation-adjusted S&P 500 price in January 2000 dollars",
             "name": "Real Price"
           },
           {
             "type": "number",
+            "description": "Inflation-adjusted dividend per share in January 2000 dollars",
             "name": "Real Dividend"
           },
           {
             "type": "number",
+            "description": "Inflation-adjusted earnings per share in January 2000 dollars",
             "name": "Real Earnings"
           },
           {


### PR DESCRIPTION
## Summary

Audit of the workflow, scripts, README, and `datapackage.json` against the actual data pipeline. All changes are documentation/metadata fixes — no data or script logic changed.

| # | File | Problem | Fix |
|---|------|---------|-----|
| 1 | `datapackage.json` | The `data` resource had no top-level `description` field | Added a one-sentence description of the resource |
| 2 | `README.md` | "monthly basis since 1870" — data starts January 1871 (confirmed by Shiller's own quote in the README and first row of `data/data.csv`) | Changed to "since 1871" |
| 3 | `README.md` | No mention of FRED — the automated CI pipeline downloads daily S&P 500 data from FRED and appends recent months, but this is invisible to dataset consumers | Added paragraph explaining the FRED extension and that FRED-only rows have `SP500` populated but all other fields (`Dividend`, `Earnings`, `CPI`, etc.) are `0` |
| 4 | `datapackage.json` | License URL uses HTTP (`http://opendatacommons.org/licenses/pddl/`) — the server issues a 301 redirect to HTTPS | Updated to `https://opendatacommons.org/licenses/pddl/` |
| 5 | `datapackage.json` | `sources` lists only Robert Shiller, but the Makefile fetches FRED data and `update_from_fred.py` appends it to the dataset on every CI run | Added Federal Reserve Bank of St. Louis (FRED) as a second source |
| 6 | `datapackage.json` | `Dividend`, `Earnings`, `Consumer Price Index`, `Real Price`, `Real Dividend`, and `Real Earnings` fields had no `description` | Added concise descriptions to all six fields |
| 7 | `actions.yml` | `pull_request` trigger declared but the job has `if: github.ref == 'refs/heads/main'` — this condition is always false for PR events (`refs/pull/N/merge`), so the job silently skips on every PR | Removed the misleading `pull_request` trigger |
| 8 | `actions.yml` | `actions/checkout@v3` and `actions/setup-python@v4` are outdated | Updated to `actions/checkout@v4` and `actions/setup-python@v5` |