### PR TITLE
Improve metadata: add package description, Date field description, README clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ FRED-only rows contain only the `SP500` price; the `Dividend`, `Earnings`,
 `Consumer Price Index`, `Long Interest Rate`, `Real Price`, `Real Dividend`,
 `Real Earnings`, and `PE10` fields are `0` for those rows.
 
+All dates are formatted as `YYYY-MM-01` (first day of the month).
+
+Note also that the `PE10` (CAPE) field is `0` for roughly the first 10 years
+of data (through ~1880), because the cyclically adjusted P/E ratio requires
+10 years of real earnings history to compute.
+
 [shiller]: http://www.econ.yale.edu/~shiller/data.htm
 [fred]: https://fred.stlouisfed.org/series/SP500
 

--- a/datapackage.json
+++ b/datapackage.json
@@ -1,6 +1,7 @@
 {
   "name": "s-and-p-500",
   "title": "Standard and Poor's (S&P) 500 Index Data including Dividend, Earnings and P/E Ratio",
+  "description": "Monthly S&P 500 index data from January 1871 to present. Includes the nominal price level, dividend per share, earnings per share, Consumer Price Index, 10-year government bond yield, inflation-adjusted price/dividend/earnings (in January 2000 dollars), and the Shiller CAPE (PE10) ratio. Historical data is sourced from Robert Shiller's dataset; recent months beyond Shiller's coverage are extended automatically using daily S&P 500 price data from FRED, averaged to monthly figures. FRED-extension rows contain only the SP500 field; all other fields are 0 for those rows.",
   "licenses": [
     {
       "name": "ODC-PDDL-1.0",
@@ -43,7 +44,8 @@
           {
             "type": "date",
             "name": "Date",
-            "format": "any"
+            "format": "any",
+            "description": "First day of the month in YYYY-MM-DD format. All observations are monthly."
           },
           {
             "type": "number",


### PR DESCRIPTION
## Changes

- **datapackage.json**: Added a top-level `description` field (was missing; title, licenses, and sources were already present)
- **datapackage.json**: Added `description` to the `Date` field — it was the only field in the schema without one
- **README.md**: Added two clarifying notes in the Data section:
  - Dates are always `YYYY-MM-01` (first day of the month)
  - `PE10` is `0` for roughly the first 10 years of data (pre-1881) because CAPE requires 10 years of real earnings history