### PR TITLE
Improve metadata: add description fields, fix date format, document PE10 zeros

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ FRED-only rows contain only the `SP500` price; the `Dividend`, `Earnings`,
 `Consumer Price Index`, `Long Interest Rate`, `Real Price`, `Real Dividend`,
 `Real Earnings`, and `PE10` fields are `0` for those rows.
 
+Additionally, `PE10` (the Shiller CAPE ratio) is `0` for the first ~10 years of the
+dataset (1871-01 through 1880-12) because computing it requires 10 years of
+trailing real earnings history, which is not yet available at the start of the series.
+
 [shiller]: http://www.econ.yale.edu/~shiller/data.htm
 [fred]: https://fred.stlouisfed.org/series/SP500
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ in the US (top 500 by market cap).
 
 The data provided here is a tidied and CSV'd version of that collected and
 prepared by the Economist Robert Shiller and made [available on his
-website][shiller]. Recent months (beyond what is covered by the Shiller
-dataset) are extended automatically with S&P 500 price data from the
-[Federal Reserve Bank of St. Louis (FRED)][fred]. Note that these
-FRED-only rows contain only the `SP500` price; the `Dividend`, `Earnings`,
-`Consumer Price Index`, `Long Interest Rate`, `Real Price`, `Real Dividend`,
-`Real Earnings`, and `PE10` fields are `0` for those rows.
+website][shiller]. The Shiller dataset currently extends through **2023-06**.
+Months after that are extended automatically with S&P 500 price data from the
+[Federal Reserve Bank of St. Louis (FRED)][fred]. Because FRED only publishes
+the index price, those rows contain only the `SP500` value; `Dividend`,
+`Earnings`, `Consumer Price Index`, `Long Interest Rate`, `Real Price`,
+`Real Dividend`, `Real Earnings`, and `PE10` are `0` for all rows from
+2023-07 onward.
 
 Additionally, `PE10` (the Shiller CAPE ratio) is `0` for the first ~10 years of the
 dataset (1871-01 through 1880-12) because computing it requires 10 years of

--- a/datapackage.json
+++ b/datapackage.json
@@ -1,6 +1,7 @@
 {
   "name": "s-and-p-500",
   "title": "Standard and Poor's (S&P) 500 Index Data including Dividend, Earnings and P/E Ratio",
+  "description": "Monthly S&P 500 index data from January 1871 to the present, sourced from Robert Shiller's dataset and extended with recent price data from the Federal Reserve Bank of St. Louis (FRED). Includes nominal and inflation-adjusted price, dividend, earnings, CPI, 10-year interest rate, and the Shiller CAPE (PE10) ratio.",
   "licenses": [
     {
       "name": "ODC-PDDL-1.0",
@@ -43,7 +44,8 @@
           {
             "type": "date",
             "name": "Date",
-            "format": "any"
+            "format": "default",
+            "description": "First day of each month in ISO 8601 format (YYYY-MM-DD). All dates are set to the 1st of the month."
           },
           {
             "type": "number",
@@ -87,7 +89,7 @@
           },
           {
             "type": "number",
-            "description": "Cyclically Adjusted Price Earnings Ratio P/E10 or CAPE",
+            "description": "Cyclically Adjusted Price Earnings Ratio P/E10 or CAPE. Values are 0.0 for 1871-01 through 1880-12 (the first 120 months) because computing PE10 requires 10 years of trailing real earnings history. Values are also 0.0 for FRED-only extension rows beyond the Shiller dataset.",
             "name": "PE10"
           }
         ]

--- a/datapackage.json
+++ b/datapackage.json
@@ -95,7 +95,7 @@
         ]
       },
       "name": "data",
-      "description": "Monthly S&P 500 index data from 1871 to present, including price, dividend, earnings, CPI, interest rate, inflation-adjusted values, and the Shiller CAPE (PE10) ratio."
+      "description": "Monthly S&P 500 index data from 1871 to present, including price, dividend, earnings, CPI, interest rate, inflation-adjusted values, and the Shiller CAPE (PE10) ratio. Recent months beyond the Shiller dataset are extended with FRED price data; for those rows only SP500 is populated and all other fields are 0."
     }
   ],
   "related": [


### PR DESCRIPTION
## Changes

- Add top-level `description` field to `datapackage.json` (was missing)
- Add `description` to the `Date` field (was the only field without one)
- Fix `Date` field `format` from `"any"` to `"default"` (ISO 8601 YYYY-MM-DD)
- Expand `PE10` field description to document that values are `0.0` for 1871-01 through 1880-12 (first 120 months lack 10 years of trailing earnings history required to compute CAPE)
- Add README note that `PE10` is `0` for the first ~10 years of the Shiller data (same reason), distinct from the already-documented FRED-only extension rows